### PR TITLE
Permitindo utilizar InAnyMethod sozinho

### DIFF
--- a/Java/SCPL/src/main/java/br/scpl/view/FileHandler.java
+++ b/Java/SCPL/src/main/java/br/scpl/view/FileHandler.java
@@ -128,6 +128,8 @@ public class FileHandler {
 		
 		String content = getStringContent(file);
 		
+		boolean inAnyMethod = false;
+		
 		if(content.toUpperCase().contains(IN_ANY_METHOD.toUpperCase())) {
 			
 			String anyMeThod = "@anyModifier\r\n" + 
@@ -143,6 +145,8 @@ public class FileHandler {
 			content = content.replaceAll("\\s+$", "");
 			
 			content = content.concat(anyMethodClose);
+			
+			inAnyMethod = true;
 		}
 		
 		if(content.contains(BEGIN) && content.contains(END)) {
@@ -194,7 +198,18 @@ public class FileHandler {
 		}
 		
 		if(files.isEmpty()) {
-			files.add(file);
+			if(inAnyMethod) {
+				File currentFile = new File(file.getAbsolutePath().replace(name, name.replace(END_JAVA_FILE, "_InAnyMethod"+END_JAVA_FILE)));
+				currentFile.deleteOnExit();
+				
+				try(FileWriter writer = new FileWriter(currentFile)){
+					writer.write(content);
+				}
+				
+				files.add(currentFile);
+			}else {
+				files.add(file);				
+			}
 		}
 				
 		return files;

--- a/Java/SCPL/src/test/java/scpl/AceitacaoTest.java
+++ b/Java/SCPL/src/test/java/scpl/AceitacaoTest.java
@@ -1414,4 +1414,24 @@ public class AceitacaoTest {
 		assertEquals(0, retorno.size());
 	}
 	
+	@Test
+	public void tc114() throws IOException {	
+				
+		List<Node> retorno = Search.searchOccurrences("./src/test/resources/AceitacaoFiles/TC114_Code.java"
+				,"./src/test/resources/AceitacaoFiles/TC114_Pattern.java");
+		
+		assertEquals(1, retorno.size());
+		assertEquals("Mensagem de teste" ,retorno.get(0).getReturnMessage());
+	}
+	
+	@Test
+	public void tc115() throws IOException {	
+				
+		List<Node> retorno = Search.searchOccurrences("./src/test/resources/AceitacaoFiles/TC115_Code.java"
+				,"./src/test/resources/AceitacaoFiles/TC115_Pattern.java");
+		
+		assertEquals(1, retorno.size());
+		assertEquals("Unchecked Integer" ,retorno.get(0).getReturnMessage());
+	}
+	
 }

--- a/Java/SCPL/src/test/resources/AceitacaoFiles/TC114_Code.java
+++ b/Java/SCPL/src/test/resources/AceitacaoFiles/TC114_Code.java
@@ -1,0 +1,5 @@
+public class SourceCode{
+    public static void run() {
+        System.out.println("Hello Nico");
+    }
+}

--- a/Java/SCPL/src/test/resources/AceitacaoFiles/TC114_Pattern.java
+++ b/Java/SCPL/src/test/resources/AceitacaoFiles/TC114_Pattern.java
@@ -1,0 +1,4 @@
+//InAnyMethod
+
+/*Alert: Mensagem de teste*/        
+System.out.println("Hello Nico");

--- a/Java/SCPL/src/test/resources/AceitacaoFiles/TC115_Code.java
+++ b/Java/SCPL/src/test/resources/AceitacaoFiles/TC115_Code.java
@@ -1,0 +1,9 @@
+public class Teste{
+
+    public void teste(){
+        String a = "";
+
+        Integer b = Integer.parseInt(a);
+        
+    }
+}

--- a/Java/SCPL/src/test/resources/AceitacaoFiles/TC115_Pattern.java
+++ b/Java/SCPL/src/test/resources/AceitacaoFiles/TC115_Pattern.java
@@ -1,0 +1,10 @@
+//InAnyMethod
+not_exists:
+try{ 
+
+  //alert: Unchecked Integer
+  Integer.parseInt(any);
+      
+}catch(anyException any){
+          
+}


### PR DESCRIPTION
Esse pull request é para resolver um problema já existente no pré processamento dos padrões. O "//InAnyMethod" estava funcionando apenas quando utilizado junto com com o "//#AND" ou o "//#OR".

Agora é possível utilizar o mesmo sozinho.